### PR TITLE
Fail when installing or importing with wrong Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
 
 script:
   - coverage run --branch -m unittest discover tests -p "*.py"
-  - flake8 . --select=C,E,F,W,B,B9 --ignore=B305,E501,E722,F401
+  - flake8 . --select=C,E,F,W,B,B9 --ignore=B305,E402,E501,E722,F401
   - cd docs && make html && cd ..
 
 after_script:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,29 @@
-import setuptools
+import sys
+
+python_requires = (3, 7)
+python_requires_str = '.'.join([str(i) for i in python_requires])
+
+error = """
+Spotipy 3.0+ supports Python {} and above, Python {} was detected.
+When using earlier versions, please install spotipy 2.4.5.
+
+See Spotipy on PyPI for more information:
+https://pypi.org/project/spotipy
+
+Try upgrading pip and retry.
+"""
+
+if sys.version_info < python_requires:
+    error.format(
+        python_requires_str,
+        '.'.join([str(i) for i in sys.version_info[:3]])
+    )
+    print(error, file=sys.stderr)
+    sys.exit(1)
+
 import os
+import setuptools
+
 from pathlib import Path
 
 root = Path(os.path.realpath(__file__)).parent
@@ -38,7 +62,7 @@ setuptools.setup(
         'spotipy': ['VERSION']
     },
 
-    python_requires='>=3.7',
+    python_requires='>=' + python_requires_str,
     install_requires=[
         'requests',
     ],
@@ -58,7 +82,7 @@ setuptools.setup(
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: ' + python_requires_str,
         'Programming Language :: Python :: 3 :: Only',
     ],
 )

--- a/spotipy/__init__.py
+++ b/spotipy/__init__.py
@@ -4,6 +4,9 @@ from pathlib import Path as _Path
 from spotipy.auth import Token, Credentials
 from spotipy.scope import Scope, scopes
 from spotipy.client import Spotify
+from spotipy._verify import _check_version
 
 _version_file = _Path(_os.path.realpath(__file__)).parent / 'VERSION'
 __version__ = _version_file.read_text().strip()
+
+_check_version()

--- a/spotipy/_verify.py
+++ b/spotipy/_verify.py
@@ -1,0 +1,33 @@
+import sys as _sys
+
+_required_version = (3, 7)
+_error_msg = """You are running Spotipy 3.x on Python <{0}!
+
+Spotipy 3.0 and above are no longer compatible with Python <{0}, and you still
+ended up with this version installed. That's unfortunate; sorry about that.
+It should not have happened. Make sure you have pip >= 9.0 to avoid this kind
+of issue, as well as setuptools >= 24.2:
+
+    $ pip install pip setuptools --upgrade
+
+Your choices:
+- Upgrade to Python {0}
+- Install an older version of Spotipy
+
+    $ pip install 'spotipy=2.4.5'
+
+It would be great if you can figure out how this version ended up being
+installed, and try to check how to prevent that for future users.
+
+See the PyPI page for more up-to-date information:
+https://pypi.org/project/spotipy
+"""
+
+
+def _check_version():
+    """
+    Verify that the Python version is acceptable.
+    """
+    if _sys.version_info < _required_version:
+        _required_version_str = '.'.join(str(i) for i in _required_version)
+        raise ImportError(_error_msg.format(_required_version_str))

--- a/tests/_verify.py
+++ b/tests/_verify.py
@@ -1,0 +1,13 @@
+import unittest
+from unittest.mock import patch
+
+from spotipy._verify import _check_version
+
+
+class TestPackage(unittest.TestCase):
+    def test_too_small_python_version_raises(self):
+        version_info = (3, 6, 5)
+
+        with patch('sys.version_info', version_info):
+            with self.assertRaises(ImportError):
+                _check_version()


### PR DESCRIPTION
Create safety measures for cases when the package is installed or imported with an incorrect Python version as discussed in [this comment](https://github.com/felix-hilden/spotipy/issues/22#issuecomment-545291674).