### PR TITLE
Expect ValueError on failed JSON decoding

### DIFF
--- a/spotipy/client/base.py
+++ b/spotipy/client/base.py
@@ -109,7 +109,7 @@ class SpotifyBase:
     def _parse_json(response):
         try:
             return response.json()
-        except json.decoder.JSONDecodeError:
+        except ValueError:
             return None
 
     def _request(


### PR DESCRIPTION
Fixes #44. Requests [documentation](https://requests.kennethreitz.org/en/master/user/quickstart/#json-response-content) states that `ValueError` should be expected on failed JSON decoding.