### PR TITLE
Improve scope module

### DIFF
--- a/spotipy/client/library.py
+++ b/spotipy/client/library.py
@@ -14,7 +14,7 @@ class SpotifyLibrary(SpotifyBase):
         """
         Get a list of the albums saved in the current user's Your Music library.
 
-        Requires the user-libray-read scope.
+        Requires the user-library-read scope.
 
         Parameters
         ----------


### PR DESCRIPTION
Fixes #92 to remove the need to go through `Scope` when combining `scopes` and provide better addition and subtraction behaviour.