### PR TITLE
Credentials senders

### DIFF
--- a/docs/documents/advanced_usage.rst
+++ b/docs/documents/advanced_usage.rst
@@ -104,8 +104,9 @@ Its functionality, however, can be extended in a number of ways
 using different kinds of :ref:`senders <module-sender>`.
 They provide the immediate
 `advantages <https://2.python-requests.org/en/master/user/advanced/#session-objects>`_
-of using a :class:`requests.Session`, can bring new functionality
-and may also use user-defined sessions.
+of using a :class:`requests.Session`.
+They can bring new functionality, use user-defined sessions
+and pass additional keyword arguments to :class:`Session.send`.
 For example per-instance sessions can be enabled with a :class:`PersistentSender`.
 
 .. code:: python

--- a/docs/reference/auth.rst
+++ b/docs/reference/auth.rst
@@ -3,3 +3,4 @@
 .. automodule:: spotipy.auth
    :members:
    :undoc-members:
+   :show-inheritance:

--- a/docs/reference/client.rst
+++ b/docs/reference/client.rst
@@ -22,16 +22,6 @@ Further documentation on endpoints can be viewed in the Web API
     for track in album.tracks.items:
         print(track.track_number, track.name)
 
-Full client
------------
-
-.. autoclass:: spotipy.client.Spotify
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-   .. automethod:: spotipy.client.Spotify.__init__
-
 .. _client-base:
 
 Base class
@@ -44,6 +34,15 @@ but also exposes a number of useful methods related to paging and tokens.
 .. autoclass:: spotipy.client.base.SpotifyBase
    :members:
    :undoc-members:
+   :show-inheritance:
+
+Full client
+-----------
+
+.. autoclass:: spotipy.client.Spotify
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Album API
 ---------

--- a/spotipy/auth.py
+++ b/spotipy/auth.py
@@ -134,18 +134,15 @@ class Credentials(Client):
         whitelisted redirect URI
     sender
         request sender
-    requests_kwargs
-        keyword arguments for requests.request
     """
     def __init__(
             self,
             client_id: str,
             client_secret: str,
             redirect_uri: str = None,
-            sender: Sender = None,
-            requests_kwargs: dict = None
+            sender: Sender = None
     ):
-        super().__init__(sender, requests_kwargs)
+        super().__init__(sender)
         self.client_id = client_id
         self.client_secret = client_secret
         self.redirect_uri = redirect_uri

--- a/spotipy/client/base.py
+++ b/spotipy/client/base.py
@@ -43,18 +43,15 @@ class SpotifyBase(Client):
         bearer token for requests
     sender
         request sender
-    requests_kwargs
-        keyword arguments for requests.request
     """
     prefix = 'https://api.spotify.com/v1/'
 
     def __init__(
             self,
             token=None,
-            sender: Sender = None,
-            requests_kwargs: dict = None
+            sender: Sender = None
     ):
-        super().__init__(sender, requests_kwargs)
+        super().__init__(sender)
         self._token = token
 
     @property

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -133,23 +133,19 @@ class RefreshingCredentials:
         whitelisted redirect URI
     sender
         request sender
-    requests_kwargs
-        keyword arguments for requests.request
     """
     def __init__(
             self,
             client_id: str,
             client_secret: str,
             redirect_uri: str = None,
-            sender: Sender = None,
-            requests_kwargs: dict = None
+            sender: Sender = None
     ):
         self._client = Credentials(
             client_id,
             client_secret,
             redirect_uri,
-            sender,
-            requests_kwargs
+            sender
         )
 
     def request_client_token(self) -> RefreshingToken:

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -130,14 +130,22 @@ class RefreshingCredentials:
         client secret
     redirect_uri
         whitelisted redirect URI
+    requests_kwargs
+        keyword arguments for requests.request
     """
     def __init__(
             self,
             client_id: str,
             client_secret: str,
-            redirect_uri: str = None
+            redirect_uri: str = None,
+            requests_kwargs: dict = None
     ):
-        self._client = Credentials(client_id, client_secret, redirect_uri)
+        self._client = Credentials(
+            client_id,
+            client_secret,
+            redirect_uri,
+            requests_kwargs
+        )
 
     def request_client_token(self) -> RefreshingToken:
         """

--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -55,6 +55,7 @@ import webbrowser
 
 from urllib.parse import urlparse, parse_qs
 from spotipy.auth import AccessToken, Token, Credentials
+from spotipy.sender import Sender
 
 
 class RefreshingToken(AccessToken):
@@ -130,6 +131,8 @@ class RefreshingCredentials:
         client secret
     redirect_uri
         whitelisted redirect URI
+    sender
+        request sender
     requests_kwargs
         keyword arguments for requests.request
     """
@@ -138,12 +141,14 @@ class RefreshingCredentials:
             client_id: str,
             client_secret: str,
             redirect_uri: str = None,
+            sender: Sender = None,
             requests_kwargs: dict = None
     ):
         self._client = Credentials(
             client_id,
             client_secret,
             redirect_uri,
+            sender,
             requests_kwargs
         )
 

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -99,8 +99,8 @@ class TestCredentialsOffline(unittest.TestCase):
     def test_server_error_raises_http_error(self):
         c = Credentials('id', 'secret')
 
-        post_mock = MagicMock(return_value=mock_response(500))
-        with patch('spotipy.auth.post', post_mock):
+        send = MagicMock(return_value=mock_response(500))
+        with patch('spotipy.auth.Credentials._send', send):
             with self.assertRaises(HTTPError):
                 c.request_client_token()
 
@@ -113,10 +113,10 @@ class TestCredentialsOffline(unittest.TestCase):
 
     def test_request_user_token(self):
         c = Credentials('id', 'secret', 'uri')
-        post = MagicMock(return_value=mock_response())
-        with patch('spotipy.auth.post', post):
+        send = MagicMock(return_value=mock_response())
+        with patch('spotipy.auth.Credentials._send', send):
             c.request_user_token('code')
-            post.assert_called_once()
+            send.assert_called_once()
 
     def test_refresh_user_token_uses_old_refresh_if_not_returned(self):
         c = Credentials('id', 'secret', 'uri')
@@ -124,8 +124,8 @@ class TestCredentialsOffline(unittest.TestCase):
         token['refresh_token'] = None
         response = mock_response(content=token)
 
-        post = MagicMock(return_value=response)
-        with patch('spotipy.auth.post', post):
+        send = MagicMock(return_value=response)
+        with patch('spotipy.auth.Credentials._send', send):
             refreshed = c.refresh_user_token('refresh')
             self.assertEqual(refreshed.refresh_token, 'refresh')
 
@@ -134,8 +134,8 @@ class TestCredentialsOffline(unittest.TestCase):
         token = make_token()
         response = mock_response(content=token)
 
-        post = MagicMock(return_value=response)
-        with patch('spotipy.auth.post', post):
+        send = MagicMock(return_value=response)
+        with patch('spotipy.auth.Credentials._send', send):
             refreshed = c.refresh_user_token('refresh')
             self.assertEqual(refreshed.refresh_token, token['refresh_token'])
 

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -2,7 +2,9 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from requests import HTTPError
-from spotipy.auth import AccessToken, Token, Credentials, OAuthError, request_token
+from spotipy.auth import AccessToken, Token, Credentials, OAuthError
+
+from tests.client._cred import TestCaseWithEnvironment
 
 
 class TestAccessToken(unittest.TestCase):
@@ -64,43 +66,43 @@ class TestToken(unittest.TestCase):
             self.assertEqual(token.is_expiring, True)
 
 
-class TestCredentials(unittest.TestCase):
-    def test_credentials_takes_arguments(self):
+def mock_response(code: int = 200, content: dict = None) -> MagicMock:
+    response = MagicMock()
+    response.status_code = code
+    response.json = MagicMock(return_value=content or make_token())
+    return response
+
+
+class TestCredentialsOnline(TestCaseWithEnvironment):
+    def test_request_client_token(self):
+        c = Credentials(self.client_id, self.client_secret)
+        c.request_client_token()
+
+    def test_refresh_user_token(self):
+        c = Credentials(self.client_id, self.client_secret)
+        c.refresh_user_token(self.user_refresh)
+
+    def test_bad_arguments_raises_oauth_error(self):
+        c = Credentials('id', 'secret')
+
+        with self.assertRaises(OAuthError):
+            c.request_client_token()
+
+
+class TestCredentialsOffline(unittest.TestCase):
+    def test_credentials_initialisation(self):
         Credentials(client_id='id', client_secret='secret', redirect_uri='uri')
 
-    def test_request_token(self):
-        response = MagicMock()
-        response.status_code = 200
-
-        post_mock = MagicMock(return_value=response)
-        with patch('spotipy.auth.post', post_mock):
-            request_token('auth', {})
-            post_mock.assert_called_once()
-
-    def test_bad_code_raises_oauth_error(self):
-        response = MagicMock()
-        response.status_code = 400
-
-        post_mock = MagicMock(return_value=response)
-        with patch('spotipy.auth.post', post_mock):
-            with self.assertRaises(OAuthError):
-                request_token('auth', {})
+    def test_credentials_init_redirect_uri_optional(self):
+        Credentials('id', 'secret')
 
     def test_server_error_raises_http_error(self):
-        response = MagicMock()
-        response.status_code = 500
+        c = Credentials('id', 'secret')
 
-        post_mock = MagicMock(return_value=response)
+        post_mock = MagicMock(return_value=mock_response(500))
         with patch('spotipy.auth.post', post_mock):
             with self.assertRaises(HTTPError):
-                request_token('auth', {})
-
-    def test_request_client_token(self):
-        c = Credentials('id', 'secret', 'uri')
-        mock = MagicMock()
-        with patch('spotipy.auth.request_token', mock):
-            c.request_client_token()
-            mock.assert_called_once()
+                c.request_client_token()
 
     def test_user_authorisation_url(self):
         c = Credentials('id', 'secret', 'uri')
@@ -111,37 +113,48 @@ class TestCredentials(unittest.TestCase):
 
     def test_request_user_token(self):
         c = Credentials('id', 'secret', 'uri')
-        mock = MagicMock()
-        with patch('spotipy.auth.request_token', mock):
+        post = MagicMock(return_value=mock_response())
+        with patch('spotipy.auth.post', post):
             c.request_user_token('code')
-            mock.assert_called_once()
+            post.assert_called_once()
 
-    def test_request_refreshed_token(self):
+    def test_refresh_user_token_uses_old_refresh_if_not_returned(self):
         c = Credentials('id', 'secret', 'uri')
-        request_token_mock = MagicMock(return_value=MagicMock())
-        with patch('spotipy.auth.request_token', request_token_mock):
-            c.refresh_user_token('refresh')
+        token = make_token()
+        token['refresh_token'] = None
+        response = mock_response(content=token)
 
-    def test_request_refreshed_token_uses_old_if_not_returned(self):
-        c = Credentials('id', 'secret', 'uri')
-        new = MagicMock()
-        new.refresh_token = None
-
-        request_token_mock = MagicMock(return_value=new)
-        with patch('spotipy.auth.request_token', request_token_mock):
+        post = MagicMock(return_value=response)
+        with patch('spotipy.auth.post', post):
             refreshed = c.refresh_user_token('refresh')
             self.assertEqual(refreshed.refresh_token, 'refresh')
 
-    def test_refresh_wraps_token_refresh_token(self):
+    def test_refresh_user_token_refresh_replaced_if_returned(self):
+        c = Credentials('id', 'secret', 'uri')
+        token = make_token()
+        response = mock_response(content=token)
+
+        post = MagicMock(return_value=response)
+        with patch('spotipy.auth.post', post):
+            refreshed = c.refresh_user_token('refresh')
+            self.assertEqual(refreshed.refresh_token, token['refresh_token'])
+
+    def test_refresh_none_refresh_interpreted_as_client_token(self):
+        c = Credentials('id', 'secret', 'uri')
+        token = MagicMock()
+        token.refresh_token = None
+
+        mock = MagicMock()
+        with patch('spotipy.auth.Credentials.request_client_token', mock):
+            c.refresh(token)
+            mock.assert_called_once()
+
+    def test_refresh_valid_refresh_interpreted_as_user_token(self):
+        c = Credentials('id', 'secret', 'uri')
         token = MagicMock()
         token.refresh_token = 'refresh'
 
-        new = MagicMock()
-        mock = MagicMock(return_value=new)
+        mock = MagicMock()
         with patch('spotipy.auth.Credentials.refresh_user_token', mock):
-            c = Credentials('id', 'secret', 'uri')
-            refreshed = c.refresh(token)
-            with self.subTest('Refresh token extracted'):
-                mock.assert_called_with('refresh')
-            with self.subTest('Refreshed token returned as is'):
-                self.assertIs(refreshed, new)
+            c.refresh(token)
+            mock.assert_called_once()

--- a/tests/client/_cred.py
+++ b/tests/client/_cred.py
@@ -19,18 +19,57 @@ def skip_or_fail(ex_type: type, msg: str, ex: Exception = None):
         raise err(msg) from ex
 
 
-class TestCaseWithCredentials(TestCase):
+class TestCaseWithAppEnvironment(TestCase):
+    """
+    Test case that retrieves application credentials from the environment.
+    """
     @classmethod
     def setUpClass(cls):
-        id_, secret, redirect = credentials_from_environment()
-        if any(i is None for i in (id_, secret, redirect)):
+        super().setUpClass()
+
+        cred = credentials_from_environment()
+        if any(i is None for i in cred):
             skip_or_fail(KeyError, 'No application credentials!')
 
-        cls.client_id = id_
-        cls.client_secret = secret
-        cls.redirect_uri = redirect
+        cls.client_id, cls.client_secret, cls.redirect_uri = cred
 
-        cls.cred = Credentials(id_, secret, redirect)
+
+class TestCaseWithUserEnvironment(TestCase):
+    """
+    Test case that retrieves user credentials from the environment.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.user_refresh, = read_environment('SPOTIPY_USER_REFRESH')
+        if cls.user_refresh is None:
+            skip_or_fail(KeyError, 'No application credentials!')
+
+
+class TestCaseWithEnvironment(
+    TestCaseWithAppEnvironment,
+    TestCaseWithUserEnvironment
+):
+    """
+    Test case that retrieves both application and user credentials
+    from the environment.
+    """
+
+
+class TestCaseWithCredentials(TestCaseWithAppEnvironment):
+    """
+    Test case that provides an application token based on the environment.
+    """
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.cred = Credentials(
+            cls.client_id,
+            cls.client_secret,
+            cls.redirect_uri
+        )
 
         try:
             cls.app_token = cls.cred.request_client_token()
@@ -38,17 +77,19 @@ class TestCaseWithCredentials(TestCase):
             skip_or_fail(HTTPError, 'Error in retrieving application token!', e)
 
 
-class TestCaseWithUserCredentials(TestCaseWithCredentials):
+class TestCaseWithUserCredentials(
+    TestCaseWithCredentials,
+    TestCaseWithUserEnvironment
+):
+    """
+    Test case that provides both application and user tokens.
+    """
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
-        refresh = read_environment('SPOTIPY_USER_REFRESH')
-        if refresh is None:
-            skip_or_fail(KeyError, 'No application credentials!')
-
         try:
-            cls.user_token = cls.cred.refresh_user_token(refresh)
+            cls.user_token = cls.cred.refresh_user_token(cls.user_refresh)
         except HTTPError as e:
             skip_or_fail(HTTPError, 'Error in retrieving user token!', e)
 

--- a/tests/sender.py
+++ b/tests/sender.py
@@ -191,5 +191,27 @@ class TestRetryingSender(unittest.TestCase):
         self.assertEqual(sender.send.call_count, 4)
 
 
+class TestDefaultSender(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from spotipy.sender import default_sender_type
+        cls.old_default = default_sender_type
+
+    def test_modify_default_sender_type(self):
+        instance = MagicMock()
+        type_mock = MagicMock(return_value=instance)
+
+        from spotipy import sender, Spotify
+        sender.default_sender_type = type_mock
+
+        s = Spotify()
+        self.assertIs(s.sender, instance)
+
+    @classmethod
+    def tearDownClass(cls):
+        from spotipy import sender
+        sender.default_sender_type = cls.old_default
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #108 

Now only senders are passed to clients, and requests kwargs are passed to those senders. Default senders and kwargs can be changed.